### PR TITLE
Change stream endpoints

### DIFF
--- a/LunaticPlayer.GRadioAPI/Clients/ApiClient.cs
+++ b/LunaticPlayer.GRadioAPI/Clients/ApiClient.cs
@@ -9,7 +9,7 @@ namespace LunaticPlayer.GRadioAPI.Clients
 {
     public class ApiClient : IApiClient
     {
-        public static string StreamUrl = "http://stream.gensokyoradio.net:8000/stream/1/";
+        public static string StreamUrl = "https://stream.gensokyoradio.net/1/";
         public const string ApiUrl = "https://gensokyoradio.net/xml/";
 
         public StructuredApiData CurrentStructuredApiData { get; private set; }

--- a/LunaticPlayer.GRadioAPI/Clients/JsonApiClient.cs
+++ b/LunaticPlayer.GRadioAPI/Clients/JsonApiClient.cs
@@ -10,7 +10,7 @@ namespace LunaticPlayer.GRadioAPI.Clients
 {
     public class JsonApiClient : IApiClient
     {
-        public static string StreamUrl = "http://stream.gensokyoradio.net:8000/stream/1/";
+        public static string StreamUrl = "https://stream.gensokyoradio.net/1/";
         public const string ApiUrl = "https://gensokyoradio.net/json/";
 
         public ApiSong CurrentApiSong { get; private set; }


### PR DESCRIPTION
Fixes #15?

So `http://stream.gensokyoradio.net:8000/stream/1/` does not exist anymore so I changed it to `https://stream.gensokyoradio.net/1/`

Sadly I don't know if this makes the player work again, because I cant get it to build. *(I have negative .NET experience)*
So if anyone is willing to test it please that would be a big help.